### PR TITLE
Use ModuleWeaver.FindType rather than ModuleDefinition.FindType

### DIFF
--- a/SexyProxy.Fody/CecilExtensions.cs
+++ b/SexyProxy.Fody/CecilExtensions.cs
@@ -31,17 +31,17 @@ namespace SexyProxy.Fody
         private static TypeReference taskTType;
         private static MethodReference taskFromResult;
 
-        internal static void Initialize(ModuleDefinition moduleDefinition)
+        internal static void Initialize(ModuleWeaver definition, ModuleDefinition moduleDefinition)
         {
             ModuleDefinition = moduleDefinition;
-            typeType = ModuleDefinition.Import(typeof(Type));
-            taskType = ModuleDefinition.Import(typeof(Task));
-            getTypeFromRuntimeHandleMethod = ModuleDefinition.Import(typeType.Resolve().Methods.Single(x => x.Name == "GetTypeFromHandle"));
-            typeGetMethod = ModuleDefinition.Import(typeType.Resolve().Methods.Single(x => x.Name == "GetMethod" && x.Parameters.Count == 5));
+            typeType = definition.FindType(typeof(Type).FullName);
+            taskType = definition.FindType(typeof(Task).FullName);
+            var typeTypeResolved = typeType.Resolve();
+            getTypeFromRuntimeHandleMethod = ModuleDefinition.Import(typeTypeResolved.Methods.Single(x => x.Name == "GetTypeFromHandle"));
+            typeGetMethod = ModuleDefinition.Import(typeTypeResolved.Methods.Single(x => x.Name == "GetMethod" && x.Parameters.Count == 5));
             taskTType = ModuleDefinition.Import(typeof(Task<>));
             taskFromResult = ModuleDefinition.Import(taskType.Resolve().Methods.Single(x => x.Name == "FromResult"));
         }
-
         public static AssemblyNameReference FindAssembly(this ModuleDefinition module, string name)
         {
             return module.AssemblyReferences

--- a/SexyProxy.Fody/ModuleWeaver.cs
+++ b/SexyProxy.Fody/ModuleWeaver.cs
@@ -21,10 +21,11 @@ namespace SexyProxy.Fody
             CecilExtensions.LogError = LogError;
             CecilExtensions.LogInfo = LogInfo;
             CecilExtensions.LogWarning = LogWarning;
-            CecilExtensions.Initialize(ModuleDefinition);
+            CecilExtensions.Initialize(this, ModuleDefinition);
 
             var propertyWeaver = new SexyProxyWeaver
             {
+                ModuleWeaver = this,
                 ModuleDefinition = ModuleDefinition,
                 LogInfo = LogInfo,
                 LogWarning = LogWarning,

--- a/SexyProxy.Fody/SexyProxy.Fody.csproj
+++ b/SexyProxy.Fody/SexyProxy.Fody.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/SexyProxy.Fody/SexyProxyWeaver.cs
+++ b/SexyProxy.Fody/SexyProxyWeaver.cs
@@ -11,6 +11,8 @@ namespace SexyProxy.Fody
 {
     public class SexyProxyWeaver
     {
+        public ModuleWeaver ModuleWeaver { get; set; }
+
         public ModuleDefinition ModuleDefinition { get; set; }
 
         // Will log an MessageImportance.High message to MSBuild. OPTIONAL
@@ -45,13 +47,15 @@ namespace SexyProxy.Fody
             var proxyFors = ModuleDefinition.Assembly.GetCustomAttributes(proxyForAttribute).Select(x => (TypeReference)x.ConstructorArguments.Single().Value).Select(x => x.Resolve()).ToArray();
             targetTypes = targetTypes.Concat(proxyFors).ToArray();
 
-            var methodInfoType = ModuleDefinition.Import(typeof(MethodInfo));
-            var propertyInfoType = ModuleDefinition.Import(typeof(PropertyInfo));
+            var methodInfoType = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(MethodInfo).FullName));
+            var propertyInfoType = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(PropertyInfo).FullName));
 
-            var func2Type = ModuleDefinition.Import(typeof(Func<,>));
-            var action1Type = ModuleDefinition.Import(typeof(Action<>));
+            var func2Type = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(Func<,>).FullName));
+            var action1Type = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(Action<>).FullName));
+            // for some reason this does not work:
+            //var objectArrayType = ModuleDefinition.Import(ModuleDefinition.FindType(typeof(object[])));
             var objectArrayType = ModuleDefinition.Import(typeof(object[]));
-            var taskType = ModuleDefinition.Import(typeof(Task));
+            var taskType = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(Task).FullName));
             var invocationTType = ModuleDefinition.FindType("SexyProxy", "InvocationT`1", sexyProxy, "T");
             var asyncInvocationTType = ModuleDefinition.FindType("SexyProxy", "AsyncInvocationT`1", sexyProxy, "T");
             var invocationHandlerType = ModuleDefinition.FindType("SexyProxy", "InvocationHandler", sexyProxy);
@@ -64,13 +68,13 @@ namespace SexyProxy.Fody
             var asyncVoidInvokeMethod = ModuleDefinition.FindMethod(invocationHandlerType, "VoidAsyncInvoke");
             var invokeTMethod = ModuleDefinition.FindMethod(invocationHandlerType, "InvokeT");
             var asyncInvokeTMethod = ModuleDefinition.FindMethod(invocationHandlerType, "AsyncInvokeT");
-            var objectType = ModuleDefinition.Import(typeof(object));
+            var objectType = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(object).FullName));
             var proxyGetInvocationHandlerMethod = ModuleDefinition.FindGetter(proxyInterface, "InvocationHandler");
             var reverseProxyGetInvocationHandlerMethod = ModuleDefinition.FindGetter(reverseProxyInterface, "InvocationHandler");
             var invocationType = ModuleDefinition.FindType("SexyProxy", "Invocation", sexyProxy);
             var invocationGetArguments = ModuleDefinition.FindGetter(invocationType, "Arguments");
             var invocationGetProxy = ModuleDefinition.FindGetter(invocationType, "Proxy");
-            var asyncTaskMethodBuilder = ModuleDefinition.Import(typeof(AsyncTaskMethodBuilder<>));
+            var asyncTaskMethodBuilder = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(AsyncTaskMethodBuilder<>).FullName));
             var methodFinder = ModuleDefinition.FindType("SexyProxy.Reflection", "MethodFinder`1", sexyProxy, "T");
             var findMethod = ModuleDefinition.FindMethod(methodFinder, "FindMethod");
             var findProperty = ModuleDefinition.FindMethod(methodFinder, "FindProperty");

--- a/SexyProxy.Fody/SexyProxyWeaver.cs
+++ b/SexyProxy.Fody/SexyProxyWeaver.cs
@@ -53,7 +53,7 @@ namespace SexyProxy.Fody
             var func2Type = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(Func<,>).FullName));
             var action1Type = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(Action<>).FullName));
             // for some reason this does not work:
-            //var objectArrayType = ModuleDefinition.Import(ModuleDefinition.FindType(typeof(object[])));
+            // var objectArrayType = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(object[]).FullName));
             var objectArrayType = ModuleDefinition.Import(typeof(object[]));
             var taskType = ModuleDefinition.Import(ModuleWeaver.FindType(typeof(Task).FullName));
             var invocationTType = ModuleDefinition.FindType("SexyProxy", "InvocationT`1", sexyProxy, "T");


### PR DESCRIPTION
This fixes the `dotnet build` command for netcoreapp3.1 libraries.